### PR TITLE
Daisy setup autonomous

### DIFF
--- a/2017/opmodes/DaisyAutonomous.java
+++ b/2017/opmodes/DaisyAutonomous.java
@@ -30,6 +30,7 @@ public class DaisyAutonomous extends Robot
     private final int TICKS_PER_DEGREE = DaisyConfiguration.TICKS_PER_DEGREE;
     private final double STRAIGHT_SPEED = DaisyConfiguration.STRAIGHT_SPEED;
     private final double TURN_SPEED = DaisyConfiguration.TURN_SPEED;
+    private int turnMultiplier = 1;
 
     private AutonomousPath pathChoice = AutonomousPath.CAP_BALL;
 
@@ -77,8 +78,10 @@ public class DaisyAutonomous extends Robot
     {
         if (color == Alliance.BLUE) {
             // Do blue setup.
+            turnMultiplier = -1;
         } else {
             // Do red setup.
+            turnMultiplier = 1;
         }
     }
 
@@ -88,38 +91,37 @@ public class DaisyAutonomous extends Robot
                 frontLeft, frontRight, rearLeft, rearRight);
 
         if (pathChoice == AutonomousPath.CORNER_PARK) {
-            path.addSegment(DeadReckon.SegmentType.STRAIGHT, 58, STRAIGHT_SPEED);
-            path.addSegment(DeadReckon.SegmentType.TURN, 120, TURN_SPEED);
-            path.addSegment(DeadReckon.SegmentType.STRAIGHT, 85, STRAIGHT_SPEED);
+            path.addSegment(DeadReckon.SegmentType.STRAIGHT,  58, STRAIGHT_SPEED);
+            path.addSegment(DeadReckon.SegmentType.TURN,     120, TURN_SPEED * turnMultiplier);
+            path.addSegment(DeadReckon.SegmentType.STRAIGHT,  85, STRAIGHT_SPEED);
         } else if (pathChoice == AutonomousPath.CENTER_PARK) {
-            path.addSegment(DeadReckon.SegmentType.STRAIGHT, 60,  STRAIGHT_SPEED);
+            path.addSegment(DeadReckon.SegmentType.STRAIGHT,  60, STRAIGHT_SPEED);
         } else if (pathChoice == AutonomousPath.CAP_BALL) {
-            path.addSegment(DeadReckon.SegmentType.STRAIGHT, 60,  STRAIGHT_SPEED);
+            path.addSegment(DeadReckon.SegmentType.STRAIGHT,  60, STRAIGHT_SPEED);
         } else if (pathChoice == AutonomousPath.LAUNCH) {
-            path.addSegment(DeadReckon.SegmentType.STRAIGHT, 0, STRAIGHT_SPEED);
+            path.addSegment(DeadReckon.SegmentType.STRAIGHT,   0, STRAIGHT_SPEED);
         }
 
         return path;
     }
 
-
     @Override
     public void init()
     {
-        frontLeft = hardwareMap.dcMotor.get("frontLeft");
+        frontLeft  = hardwareMap.dcMotor.get("frontLeft");
         frontRight = hardwareMap.dcMotor.get("frontRight");
-        rearLeft = hardwareMap.dcMotor.get("rearLeft");
-        rearRight = hardwareMap.dcMotor.get("rearRight");
+        rearLeft   = hardwareMap.dcMotor.get("rearLeft");
+        rearRight  = hardwareMap.dcMotor.get("rearRight");
 
         // Telemetry setup.
         ptt = new PersistentTelemetryTask(this);
         this.addTask(ptt);
-        ptt.addData("Press (x) to select", "Blue alliance!");
-        ptt.addData("Press (b) to select", "Red alliance!");
-        ptt.addData("Press (Left Bumper) to select", "Corner Park!");
-        ptt.addData("Press (Right Trigger) to select", "Center Park!");
-        ptt.addData("Press (Right Bumper) to select", "Cap Ball!");
-        ptt.addData("Press (Left Trigger) to select", "Launch!");
+        ptt.addData("Press (X) to select", "Blue alliance!");
+        ptt.addData("Press (B) to select", "Red alliance!");
+        ptt.addData("Press (LEFT BUMPER) to select", "Corner Park!");
+        ptt.addData("Press (RIGHT TRIGGER) to select", "Center Park!");
+        ptt.addData("Press (RIGHT BUMPER) to select", "Cap Ball!");
+        ptt.addData("Press (LEFT TRIGGER) to select", "Launch!");
 
         // Alliance selection.
         this.addTask(new GamepadTask(this, GamepadTask.GamepadNumber.GAMEPAD_1));

--- a/2017/opmodes/DaisyLaunchAutonomous.java
+++ b/2017/opmodes/DaisyLaunchAutonomous.java
@@ -29,10 +29,6 @@ public class DaisyLaunchAutonomous extends Robot
     private DcMotor conveyor;
     private DeadReckonTask deadReckonTask;
     private RunToEncoderValueTask runToPositionTask;
-    private DeadmanMotorTask runLauncherBackTask;
-    private DeadmanMotorTask runLauncherForwardTask;
-    private DeadmanMotorTask runConveyorForwardTask;
-    private DeadmanMotorTask runConveyorBackTask;
     private SingleShotTimerTask stt;
     private boolean launched;
     private FourWheelDirectDriveDeadReckon path;
@@ -56,7 +52,6 @@ public class DaisyLaunchAutonomous extends Robot
                     addTask(stt);
                     launched = true;
                 } else {
-                    // add dead reckon task here
                     path = new FourWheelDirectDriveDeadReckon(this, TICKS_PER_INCH, TICKS_PER_DEGREE, frontRight,
                             rearRight, frontLeft, rearLeft);
                     path.addSegment(DeadReckon.SegmentType.STRAIGHT, 58, STRAIGHT_SPEED);
@@ -64,7 +59,6 @@ public class DaisyLaunchAutonomous extends Robot
                     path.addSegment(DeadReckon.SegmentType.STRAIGHT, 80, STRAIGHT_SPEED);
                     deadReckonTask = new DeadReckonTask(this, path);
                     addTask(deadReckonTask);
-
                 }
             }
         }
@@ -93,18 +87,6 @@ public class DaisyLaunchAutonomous extends Robot
         launcher.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
         launcher.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
 
-        /*
-        runLauncherForwardTask = new DeadmanMotorTask(this, launcher, 0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_Y);
-        runLauncherBackTask = new DeadmanMotorTask(this, launcher, -0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_A);
-        runConveyorForwardTask = new DeadmanMotorTask(this, conveyor, 0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_X);
-        runConveyorBackTask = new DeadmanMotorTask(this, conveyor, -0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_B);
-
-        addTask(runLauncherForwardTask);
-        addTask(runLauncherBackTask);
-        addTask(runConveyorForwardTask);
-        addTask(runConveyorBackTask);
-        */
-
         stt = new SingleShotTimerTask(this, 2000);
         launched = false;
     }
@@ -112,18 +94,6 @@ public class DaisyLaunchAutonomous extends Robot
     @Override
     public void start()
     {
-        /*
-        runLauncherForwardTask = new DeadmanMotorTask(this, launcher, 0.0, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_Y);
-        runLauncherBackTask = new DeadmanMotorTask(this, launcher, -0.0, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_A);
-        runConveyorForwardTask = new DeadmanMotorTask(this, conveyor, 0.0, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_X);
-        runConveyorBackTask = new DeadmanMotorTask(this, conveyor, -0.0, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_B);
-
-        addTask(runLauncherForwardTask);
-        addTask(runLauncherBackTask);
-        addTask(runConveyorForwardTask);
-        addTask(runConveyorBackTask);
-        */
-
         addTask(runToPositionTask);
     }
 }

--- a/2017/opmodes/DaisySetupTeleop.java
+++ b/2017/opmodes/DaisySetupTeleop.java
@@ -1,0 +1,63 @@
+package opmodes;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.hardware.DcMotor;
+
+import team25core.DeadmanMotorTask;
+import team25core.GamepadTask;
+import team25core.Robot;
+import team25core.RobotEvent;
+
+/**
+ * FTC Team 25: Created by Katelyn Biesiadecki on 12/3/2016.
+ */
+
+@Autonomous(name = "Daisy: Setup for Autonomous", group = "Team25")
+public class DaisySetupTeleop extends Robot
+{
+    /*
+
+    GAMEPAD 1: MECHANISM CONTROLLER
+    --------------------------------------------------------------------------------------------
+      (L trigger)        (R trigger)    |
+      (L bumper)         (R bumper)     |
+                            (y)         | (y) run launcher forward
+      arrow pad          (x)   (b)      | (x) run conveyor forward    (b) run conveyor backward
+                            (a)         | (a) run launcher backward
+
+    */
+
+    private DcMotor launcher;
+    private DcMotor conveyor;
+    private DeadmanMotorTask runLauncherBackTask;
+    private DeadmanMotorTask runLauncherForwardTask;
+    private DeadmanMotorTask runConveyorForwardTask;
+    private DeadmanMotorTask runConveyorBackTask;
+
+    @Override
+    public void handleEvent(RobotEvent e)
+    {
+       // Nothing.
+    }
+
+    @Override
+    public void init()
+    {
+        conveyor = hardwareMap.dcMotor.get("conveyor");
+        launcher = hardwareMap.dcMotor.get("launcher");
+
+        runLauncherForwardTask = new DeadmanMotorTask(this, launcher,  0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_Y);
+        runLauncherBackTask    = new DeadmanMotorTask(this, launcher, -0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_A);
+        runConveyorForwardTask = new DeadmanMotorTask(this, conveyor,  0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_X);
+        runConveyorBackTask    = new DeadmanMotorTask(this, conveyor, -0.1, GamepadTask.GamepadNumber.GAMEPAD_1, DeadmanMotorTask.DeadmanButton.BUTTON_B);
+    }
+
+    @Override
+    public void start()
+    {
+        addTask(runLauncherForwardTask);
+        addTask(runLauncherBackTask);
+        addTask(runConveyorForwardTask);
+        addTask(runConveyorBackTask);
+    }
+}

--- a/2017/opmodes/DaisyTeleop.java
+++ b/2017/opmodes/DaisyTeleop.java
@@ -104,7 +104,7 @@ public class DaisyTeleop extends Robot
         launcher    = hardwareMap.dcMotor.get("launcher");
         leftPusher  = hardwareMap.servo.get("leftPusher");
         rightPusher = hardwareMap.servo.get("rightPusher");
-        odsSwinger = hardwareMap.servo.get("odsSwinger");
+        odsSwinger  = hardwareMap.servo.get("odsSwinger");
 
         leftPusher.setPosition(leftPosition);
         rightPusher.setPosition(rightPosition);

--- a/2017/opmodes/MochaSingleDriverTeleop.java
+++ b/2017/opmodes/MochaSingleDriverTeleop.java
@@ -21,7 +21,6 @@ import team25core.Robot;
 import team25core.RobotEvent;
 
 @TeleOp(name="Baby Mocha", group = "5218")
-@Disabled
 public class MochaSingleDriverTeleop extends Robot {
 
     private final static int LED_CHANNEL = 0;

--- a/2017/opmodes/MochaSingleDriverTeleop.java
+++ b/2017/opmodes/MochaSingleDriverTeleop.java
@@ -6,6 +6,7 @@ package opmodes;
  */
 
 import com.qualcomm.hardware.modernrobotics.ModernRoboticsI2cGyro;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorController;
@@ -20,6 +21,7 @@ import team25core.Robot;
 import team25core.RobotEvent;
 
 @TeleOp(name="Baby Mocha", group = "5218")
+@Disabled
 public class MochaSingleDriverTeleop extends Robot {
 
     private final static int LED_CHANNEL = 0;

--- a/2017/opmodes/RobbieTeleop.java
+++ b/2017/opmodes/RobbieTeleop.java
@@ -21,7 +21,6 @@ import team25core.Robot;
 import team25core.RobotEvent;
 
 @TeleOp(name="THANKSGIVING", group = "5218")
-@Disabled
 public class RobbieTeleop extends Robot {
 
     private final static int LED_CHANNEL = 0;

--- a/2017/opmodes/RobbieTeleop.java
+++ b/2017/opmodes/RobbieTeleop.java
@@ -6,6 +6,7 @@ package opmodes;
  */
 
 import com.qualcomm.hardware.modernrobotics.ModernRoboticsI2cGyro;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorController;
@@ -20,6 +21,7 @@ import team25core.Robot;
 import team25core.RobotEvent;
 
 @TeleOp(name="THANKSGIVING", group = "5218")
+@Disabled
 public class RobbieTeleop extends Robot {
 
     private final static int LED_CHANNEL = 0;


### PR DESCRIPTION
**Changes:**
- Addition of Daisy setup opmode to prepare launcher for autonomous.

Our other autonomous opmode, DaisyAutonomous (with only parking -- no launching) gives drivers the ability to choose different options during the init() phase for alliance and parking location, but we have to be careful about when we touch the gamepads. I consulted the FTC Referee manual for the exact rules about touching gamepads during autonomous period:

> _During the autonomous period_
>- Teams may not touch the controllers after the Beacons are randomized and until the Autonomous Period is complete.
>- Watch the Drivers in the Alliance Station to be sure they do not touch the controls or any part of the Playing Field during the Autonomous Period.

So, if we select our autonomous preferences before the beacons are randomized, we should be okay penalty-wise... Please confirm or reject this theory so I can make changes to the opmodes if need be (i.e. make a red center park, blue corner park, etc.)
